### PR TITLE
Fix Patch for UDOO

### DIFF
--- a/v2018.09/0001-udoo-uEnv.txt-bootz-n-fixes.patch
+++ b/v2018.09/0001-udoo-uEnv.txt-bootz-n-fixes.patch
@@ -10,24 +10,19 @@ Signed-off-by: Robert Nelson <robertcnelson@gmail.com>
  2 files changed, 144 insertions(+), 64 deletions(-)
 
 diff --git a/configs/udoo_defconfig b/configs/udoo_defconfig
-index b92b181d4f..eff9e6e65f 100644
+index 52de8ca..d8ba6eb 100644
 --- a/configs/udoo_defconfig
 +++ b/configs/udoo_defconfig
-@@ -8,16 +8,22 @@ CONFIG_SPL_MMC_SUPPORT=y
- CONFIG_SPL_SERIAL_SUPPORT=y
- CONFIG_SPL_LIBDISK_SUPPORT=y
- CONFIG_SPL_WATCHDOG_SUPPORT=y
-+CONFIG_DISTRO_DEFAULTS=y
- CONFIG_SYS_EXTRA_OPTIONS="IMX_CONFIG=arch/arm/mach-imx/spl_sd.cfg"
- CONFIG_BOOTDELAY=3
+@@ -16,11 +16,17 @@ CONFIG_SUPPORT_RAW_INITRD=y
  CONFIG_BOARD_EARLY_INIT_F=y
- CONFIG_SPL=y
  CONFIG_SPL_EXT_SUPPORT=y
  CONFIG_SPL_I2C_SUPPORT=y
 +CONFIG_AUTOBOOT_KEYED=y
 +CONFIG_AUTOBOOT_PROMPT="Press SPACE to abort autoboot in %d seconds\n"
 +CONFIG_AUTOBOOT_DELAY_STR="d"
 +CONFIG_AUTOBOOT_STOP_STR=" "
+ CONFIG_SPL_WATCHDOG_SUPPORT=y
++CONFIG_DISTRO_DEFAULTS=y
  CONFIG_HUSH_PARSER=y
  CONFIG_CMD_BOOTZ=y
  CONFIG_CMD_GPIO=y
@@ -37,19 +32,11 @@ index b92b181d4f..eff9e6e65f 100644
  CONFIG_CMD_DHCP=y
  CONFIG_CMD_MII=y
 diff --git a/include/configs/udoo.h b/include/configs/udoo.h
-index bcce41db8a..4b83aff9c7 100644
+index 985f306..77e04f0 100644
 --- a/include/configs/udoo.h
 +++ b/include/configs/udoo.h
-@@ -9,6 +9,7 @@
- #ifndef __CONFIG_H
- #define __CONFIG_H
- 
-+#include <config_distro_defaults.h>
- #include "mx6_common.h"
- 
- #include "imx6_spl.h"
-@@ -51,19 +52,21 @@
- #define CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG
+@@ -45,19 +45,21 @@
+ #define CONFIG_SYS_FSL_ESDHC_ADDR	0
  
  #define CONFIG_EXTRA_ENV_SETTINGS \
 -	"script=boot.scr\0" \
@@ -76,7 +63,7 @@ index bcce41db8a..4b83aff9c7 100644
  	"update_sd_firmware_filename=u-boot.imx\0" \
  	"update_sd_firmware=" \
  		"if test ${ip_dyn} = yes; then " \
-@@ -78,73 +81,144 @@
+@@ -72,73 +74,144 @@
  				"mmc write ${loadaddr} 0x2 ${fw_sz}; " \
  			"fi; "	\
  		"fi\0" \
@@ -278,7 +265,7 @@ index bcce41db8a..4b83aff9c7 100644
 +#include <config_distro_bootcmd.h>
  
  /* Physical Memory Map */
- #define CONFIG_NR_DRAM_BANKS		1
+ #define PHYS_SDRAM			MMDC0_ARB_BASE_ADDR
 -- 
 2.15.0
 


### PR DESCRIPTION
The first hunk of the original patch does not apply, as the Config-Vars are somewhat scrambled. 

Including config_distro_defaults.h in include/configs/udoo.h shouldn't be necessary with v2018.09 since u-boot/u-boot@ba8bf9481b0854fa7d48b0e9ed913c639f187c7d